### PR TITLE
BUG FIX: CRUD Operations B2 - PUT (Admin can update)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
@@ -79,6 +79,9 @@ public abstract class ApiController {
     return mapper;
   }
 
+  protected Object genericMessage(String message) {
+    return Map.of("message", message);
+  }
 
   @ExceptionHandler({ AccessDeniedException.class })
   @ResponseStatus(HttpStatus.FORBIDDEN)

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
@@ -79,9 +79,6 @@ public abstract class ApiController {
     return mapper;
   }
 
-  protected Object genericMessage(String message) {
-    return Map.of("message", message);
-  }
 
   @ExceptionHandler({ AccessDeniedException.class })
   @ResponseStatus(HttpStatus.FORBIDDEN)

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -156,11 +156,14 @@ public class CoursesController extends ApiController {
             @RequestBody @Valid Course incoming) throws JsonProcessingException {
 
         User user = getCurrentUser().getUser();
+        
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
-        courseStaffRepository.findByCourseIdAndGithubId(courseId, user.getGithubId())
-        .orElseThrow(() -> new AccessDeniedException(
-            String.format("%s is not allowed to update course %d", user.getGithubLogin(), courseId)));
+        if (!user.isAdmin()) {
+                courseStaffRepository.findByCourseIdAndGithubId(courseId, user.getGithubId())
+                .orElseThrow(() -> new AccessDeniedException(
+                        String.format("%s is not allowed to update course %d", user.getGithubLogin(), courseId)));
+        }
 
         course.setName(incoming.getName());
         course.setSchool(incoming.getSchool());

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -590,7 +590,6 @@ public class CoursesControllerTests extends ControllerTestCase {
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
-                verify(courseStaffRepository, times(1)).findByCourseIdAndGithubId(eq(course1.getId()),eq(courseStaff1.getGithubId()));
                 verify(courseRepository, times(1)).findById(1L);
                 verify(courseRepository, times(1)).save(courseAfter); 
                 


### PR DESCRIPTION
Added logic to existing PUT endpoint to allow for Admin to update any courses. Changing the logic from just instructors of the course can update the course to Instructors of the course and Admins can update the course. 

deployed at qa: https://organic-qa.dokku-07.cs.ucsb.edu/

To test, need to have 2 users, or a preexisting course already on the courses index table. Then toggle instructor status to false, keeping admin status true. Then user that is admin but did not make course should be able to update the course. 

Closes #57 